### PR TITLE
修正贡献表链接和显示问题

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Speedfox(Sunnny516)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Github 上的 README 一般是用 Markdown 编写的，所以后缀名是 .md �
 
 感谢所有贡献的人，一起帮我维护这座屎山。
 
-<a href="https://github.com/remarkablemark/speedfox/graphs/contributors">
+<a href="https://github.com/sunnny516/speedfox/graphs/contributors">
   <img src="https://opencollective.com/speedfox/contributors.svg?width=890&button=false">
 </a>
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Github 上的 README 一般是用 Markdown 编写的，所以后缀名是 .md �
 
 感谢所有贡献的人，一起帮我维护这座屎山。
 
-<a href="https://github.com/sunnny516/speedfox/graphs/contributors">
-  <img src="https://opencollective.com/speedfox/contributors.svg?width=890&button=false">
+<a href="https://github.com/sunnny516/speedfox/graphs/contributors" target="_blank">
+  <img src="https://contrib.rocks/image?repo=sunnny516/speedfox" />
 </a>
 
 


### PR DESCRIPTION
贡献表中贡献者头像显示图片使用的为contrib.rocks服务

Made with [contrib.rocks](https://contrib.rocks).